### PR TITLE
Fix deprecated methods of Chainer 1.24.0

### DIFF
--- a/deepcrf/main.py
+++ b/deepcrf/main.py
@@ -63,7 +63,7 @@ def run(data_file, is_train=False, **args):
     xp = cuda.cupy if args['gpu'] >= 0 else np
     efficient_gpu = False
     if args['gpu'] >= 0:
-        cuda.get_device(args['gpu']).use()
+        cuda.get_device_from_id(args['gpu']).use()
         xp.random.seed(1234)
         efficient_gpu = args.get('efficient_gpu', False)
 
@@ -429,7 +429,7 @@ def run(data_file, is_train=False, **args):
             sum_loss += loss.data
 
             # update
-            net.zerograds()
+            net.cleargrads()
             loss.backward()
             opt.update()
 


### PR DESCRIPTION
I fixed deprecated methods of Chainer 1.24.0: `chainer.cuda.get_device` and `bi_lstm.BiLSTM_CNN_CRF.zerograds` (`chainer.Chain.zerograds`).