### PR TITLE
Support Python2.x and Python 3.x

### DIFF
--- a/deepcrf/__init__.py
+++ b/deepcrf/__init__.py
@@ -1,8 +1,8 @@
 import click
 import logging
 
-import main
-import evaluate
+import deepcrf.main
+import deepcrf.evaluate
 
 
 @click.group()

--- a/deepcrf/bi_lstm.py
+++ b/deepcrf/bi_lstm.py
@@ -19,7 +19,7 @@ from .cnn import CharCNNEncoder
 import deepcrf.util
 from .util import PADDING, UNKWORD
 
-import six
+import six.moves
 
 to_cpu = chainer.cuda.to_cpu
 

--- a/deepcrf/bi_lstm.py
+++ b/deepcrf/bi_lstm.py
@@ -15,16 +15,16 @@ import chainer.links as L
 import math
 from chainer import initializers
 
-from cnn import CharCNNEncoder
-import util
-from util import PADDING, UNKWORD
+from .cnn import CharCNNEncoder
+import deepcrf.util
+from .util import PADDING, UNKWORD
 
 import six
 
 to_cpu = chainer.cuda.to_cpu
 
 version = chainer.__version__
-from util_chainer import my_variable, my_dropout, my_set_train, my_rnn_link
+from .util_chainer import my_variable, my_dropout, my_set_train, my_rnn_link
 
 
 class BiLSTM_CNN_CRF(chainer.Chain):

--- a/deepcrf/cnn.py
+++ b/deepcrf/cnn.py
@@ -65,9 +65,7 @@ class BaseCNNEncoder(chainer.Chain):
         """
 
         padding_size = self.window_size // 2
-        padding = []
-        for i in six.moves.range(padding_size):
-            padding.extend([self.PAD_IDX])
+        padding = [self.PAD_IDX for i in six.moves.range(padding_size)]
         padding = self.xp.array(padding, dtype=self.xp.int32)
         data_num = len(data)
         ids = []

--- a/deepcrf/cnn.py
+++ b/deepcrf/cnn.py
@@ -34,7 +34,7 @@ class BaseCNNEncoder(chainer.Chain):
             conv=L.Convolution2D(1, hidden_dim,
                                  ksize=(window_size, dim),
                                  stride=(1, dim),
-                                 pad=(window_size / 2, 0))
+                                 pad=(window_size // 2, 0))
         )
         self.spliter = spliter
         self.char_level_flag = True if self.spliter is None else False
@@ -63,7 +63,7 @@ class BaseCNNEncoder(chainer.Chain):
         separator = None
         """
 
-        padding_size = self.window_size / 2
+        padding_size = self.window_size // 2
         padding = []
         for i in range(int(padding_size)):
             padding.extend([self.PAD_IDX])

--- a/deepcrf/cnn.py
+++ b/deepcrf/cnn.py
@@ -30,13 +30,9 @@ class BaseCNNEncoder(chainer.Chain):
         hidden_dim = hidden_dim + add_dim
         self.add_dim = add_dim
         self.hidden_dim = hidden_dim
-        super(BaseCNNEncoder, self).__init__(
-            emb=L.EmbedID(vocab_size, emb_dim, ignore_label=-1),
-            conv=L.Convolution2D(1, hidden_dim,
-                                 ksize=(window_size, dim),
-                                 stride=(1, dim),
-                                 pad=(window_size // 2, 0))
-        )
+        super(BaseCNNEncoder, self).__init__(emb=L.EmbedID(vocab_size, emb_dim, ignore_label=-1),
+                                             conv=L.Convolution2D(1, hidden_dim, ksize=(window_size, dim),
+                                                                  stride=(1, dim), pad=(window_size // 2, 0)))
         self.spliter = spliter
         self.char_level_flag = True if self.spliter is None else False
         self.word_level_flag = not self.char_level_flag

--- a/deepcrf/cnn.py
+++ b/deepcrf/cnn.py
@@ -8,6 +8,7 @@ from chainer import Variable, optimizers, serializers
 import chainer.functions as F
 import chainer.links as L
 import numpy as np
+import six.moves
 
 
 from .util import UNKWORD, PADDING, BOS
@@ -65,7 +66,7 @@ class BaseCNNEncoder(chainer.Chain):
 
         padding_size = self.window_size // 2
         padding = []
-        for i in range(int(padding_size)):
+        for i in six.moves.range(int(padding_size)):
             padding.extend([self.PAD_IDX])
         padding = self.xp.array(padding, dtype=self.xp.int32)
         data_num = len(data)

--- a/deepcrf/cnn.py
+++ b/deepcrf/cnn.py
@@ -10,10 +10,10 @@ import chainer.links as L
 import numpy as np
 
 
-from util import UNKWORD, PADDING, BOS
+from .util import UNKWORD, PADDING, BOS
 
 
-from util_chainer import my_variable, my_dropout, my_set_train, my_rnn_link
+from .util_chainer import my_variable, my_dropout, my_set_train, my_rnn_link
 
 
 class BaseCNNEncoder(chainer.Chain):
@@ -64,7 +64,9 @@ class BaseCNNEncoder(chainer.Chain):
         """
 
         padding_size = self.window_size / 2
-        padding = [self.PAD_IDX] * padding_size
+        padding = []
+        for i in range(int(padding_size)):
+            padding.extend([self.PAD_IDX])
         padding = self.xp.array(padding, dtype=self.xp.int32)
         data_num = len(data)
         ids = []

--- a/deepcrf/cnn.py
+++ b/deepcrf/cnn.py
@@ -66,7 +66,7 @@ class BaseCNNEncoder(chainer.Chain):
 
         padding_size = self.window_size // 2
         padding = []
-        for i in six.moves.range(int(padding_size)):
+        for i in six.moves.range(padding_size):
             padding.extend([self.PAD_IDX])
         padding = self.xp.array(padding, dtype=self.xp.int32)
         data_num = len(data)

--- a/deepcrf/evaluate.py
+++ b/deepcrf/evaluate.py
@@ -64,5 +64,5 @@ def run(gold_file, predicted_file, **args):
 
     table.print_table()
 
-    # accuracy = util.eval_accuracy(gold_predict_pairs, flag=False)
+    # accuracy = deepcrf.util.eval_accuracy(gold_predict_pairs, flag=False)
     # print('Tag Accuracy: {}'.format(accuracy))

--- a/deepcrf/evaluate.py
+++ b/deepcrf/evaluate.py
@@ -1,6 +1,6 @@
 import re
-import util
-import util_talbes
+import deepcrf.util
+import deepcrf.util_talbes
 
 
 def load_file(filename):
@@ -8,7 +8,7 @@ def load_file(filename):
     tags = []
     with open(filename) as f:
         for l in f:
-            tag = l.decode('utf-8').strip()
+            tag = deepcrf.util.str_to_unicode_2(l).strip()
             if tag == u'':
                 # sentence split
                 alltags_list.append(tags)
@@ -49,9 +49,9 @@ def run(gold_file, predicted_file, **args):
     gold_tags = replace_S_E_tags(gold_tags)
     predicted_tags = replace_S_E_tags(predicted_tags)
     gold_predict_pairs = [gold_tags, predicted_tags]
-    result, phrase_info = util.conll_eval(gold_predict_pairs, flag=False, tag_class=tag_names)
+    result, phrase_info = deepcrf.util.conll_eval(gold_predict_pairs, flag=False, tag_class=tag_names)
 
-    table = util_talbes.SimpleTable()
+    table = deepcrf.util_talbes.SimpleTable()
     table.set_header(('Tag Name', 'Precision', 'Recall', 'F_measure'))
 
     all_result = result['All_Result']

--- a/deepcrf/evaluate.py
+++ b/deepcrf/evaluate.py
@@ -8,7 +8,7 @@ def load_file(filename):
     tags = []
     with open(filename) as f:
         for l in f:
-            tag = deepcrf.util.str_to_unicode_2(l).strip()
+            tag = deepcrf.util.str_to_unicode_python2(l).strip()
             if tag == u'':
                 # sentence split
                 alltags_list.append(tags)

--- a/deepcrf/main.py
+++ b/deepcrf/main.py
@@ -86,8 +86,7 @@ def run(data_file, is_train=False, **args):
     additional_input_idx = input_idx[1:]
     sentences_train = []
     if is_train:
-        sentences_train = deepcrf.util.read_conll_file(filename=data_file,
-                                                       delimiter=delimiter)
+        sentences_train = deepcrf.util.read_conll_file(filename=data_file, delimiter=delimiter)
         if len(sentences_train) == 0:
             s = str(len(sentences_train))
             err_msg = 'Invalid training sizes: {} sentences. '.format(s)
@@ -96,12 +95,10 @@ def run(data_file, is_train=False, **args):
         # Predict
         if len(input_idx) == 1:
             # raw text format
-            sentences_train = deepcrf.util.read_raw_file(filename=data_file,
-                                                         delimiter=u' ')
+            sentences_train = deepcrf.util.read_raw_file(filename=data_file, delimiter=u' ')
         else:
             # conll format
-            sentences_train = deepcrf.util.read_conll_file(filename=data_file,
-                                                           delimiter=delimiter)
+            sentences_train = deepcrf.util.read_conll_file(filename=data_file, delimiter=delimiter)
 
     # sentences_train = sentences_train[:100]
 

--- a/deepcrf/main.py
+++ b/deepcrf/main.py
@@ -13,10 +13,10 @@ from chainer import optimizers
 from chainer import serializers
 import chainer.functions as F
 
-from bi_lstm import BiLSTM_CNN_CRF
+from .bi_lstm import BiLSTM_CNN_CRF
 
-import util
-from util import PADDING, UNKWORD
+import deepcrf.util
+from .util import PADDING, UNKWORD
 
 
 import logging
@@ -39,6 +39,9 @@ def my_cudnn(cudnn_flag):
 
 
 def run(data_file, is_train=False, **args):
+    for k in args.keys():
+        args[k] = deepcrf.util.str_to_unicode_2(args[k])
+
     is_test = not is_train
     batchsize = args['batchsize']
     model_name = args['model_name']
@@ -76,14 +79,14 @@ def run(data_file, is_train=False, **args):
     dev_file = args['dev_file']
     test_file = args['test_file']
     delimiter = args['delimiter']
-    input_idx = map(int, args['input_idx'].split(','))
-    output_idx = map(int, args['output_idx'].split(','))
+    input_idx = list(map(int, args['input_idx'].split(',')))
+    output_idx = list(map(int, args['output_idx'].split(',')))
     word_input_idx = input_idx[0]  # NOTE: word_idx is first column!
     additional_input_idx = input_idx[1:]
     sentences_train = []
     if is_train:
-        sentences_train = util.read_conll_file(filename=data_file,
-                                               delimiter=delimiter)
+        sentences_train = deepcrf.util.read_conll_file(filename=data_file,
+                                                       delimiter=delimiter)
         if len(sentences_train) == 0:
             s = str(len(sentences_train))
             err_msg = 'Invalid training sizes: {} sentences. '.format(s)
@@ -92,28 +95,28 @@ def run(data_file, is_train=False, **args):
         # Predict
         if len(input_idx) == 1:
             # raw text format
-            sentences_train = util.read_raw_file(filename=data_file,
-                                                 delimiter=u' ')
+            sentences_train = deepcrf.util.read_raw_file(filename=data_file,
+                                                         delimiter=u' ')
         else:
             # conll format
-            sentences_train = util.read_conll_file(filename=data_file,
-                                                   delimiter=delimiter)
+            sentences_train = deepcrf.util.read_conll_file(filename=data_file,
+                                                           delimiter=delimiter)
 
     # sentences_train = sentences_train[:100]
 
     sentences_dev = []
     sentences_test = []
     if dev_file:
-        sentences_dev = util.read_conll_file(dev_file, delimiter=delimiter)
+        sentences_dev = deepcrf.util.read_conll_file(dev_file, delimiter=delimiter)
     if test_file:
-        sentences_test = util.read_conll_file(test_file, delimiter=delimiter)
+        sentences_test = deepcrf.util.read_conll_file(test_file, delimiter=delimiter)
 
     # Additional setup
     vocab_adds = []
     for ad_feat_id in additional_input_idx:
         sentences_additional_train = [[feat_obj[ad_feat_id] for feat_obj in sentence]
                                       for sentence in sentences_train]
-        vocab_add = util.build_vocab(sentences_additional_train)
+        vocab_add = deepcrf.util.build_vocab(sentences_additional_train)
         vocab_adds.append(vocab_add)
 
     save_vocab = save_name + '.vocab'
@@ -127,18 +130,18 @@ def run(data_file, is_train=False, **args):
     if is_train:
         sentences_words_train = [[w_obj[word_input_idx] for w_obj in sentence]
                                  for sentence in sentences_train]
-        vocab = util.build_vocab(sentences_words_train)
-        vocab_char = util.build_vocab(util.flatten(sentences_words_train))
-        vocab_tags = util.build_tag_vocab(sentences_train)
+        vocab = deepcrf.util.build_vocab(sentences_words_train)
+        vocab_char = deepcrf.util.build_vocab(deepcrf.util.flatten(sentences_words_train))
+        vocab_tags = deepcrf.util.build_tag_vocab(sentences_train)
 
     elif is_test:
-        vocab = util.load_vocab(save_vocab)
-        vocab_char = util.load_vocab(save_vocab_char)
-        vocab_tags = util.load_vocab(save_tags_vocab)
+        vocab = deepcrf.util.load_vocab(save_vocab)
+        vocab_char = deepcrf.util.load_vocab(save_vocab_char)
+        vocab_tags = deepcrf.util.load_vocab(save_tags_vocab)
         vocab_adds = []
         for i, idx in enumerate(additional_input_idx):
             save_additional_vocab = save_name + '.vocab_additional_' + str(i)
-            vocab_add = util.load_vocab(save_additional_vocab)
+            vocab_add = deepcrf.util.load_vocab(save_additional_vocab)
             vocab_adds.append(vocab_add)
 
     if args.get('word_emb_file', False):
@@ -160,14 +163,14 @@ def run(data_file, is_train=False, **args):
 
         if word_emb_vocab_type == 'replace_all':
             # replace all vocab by Pre-trained embeddings
-            word_vecs, vocab_glove = util.load_glove_embedding_include_vocab(emb_file)
+            word_vecs, vocab_glove = deepcrf.util.load_glove_embedding_include_vocab(emb_file)
             vocab = vocab_glove
         elif word_emb_vocab_type == 'replace_only':
-            word_ids, word_vecs = util.load_glove_embedding(emb_file, vocab)
+            word_ids, word_vecs = deepcrf.util.load_glove_embedding(emb_file, vocab)
             assert_no_emb(word_vecs)
 
         elif word_emb_vocab_type == 'additional':
-            word_vecs, vocab_glove = util.load_glove_embedding_include_vocab(emb_file)
+            word_vecs, vocab_glove = deepcrf.util.load_glove_embedding_include_vocab(emb_file)
             additional_vecs = []
             for word, word_idx in sorted(vocab_glove.items(), key=lambda x: x[1]):
                 if word not in vocab:
@@ -177,11 +180,11 @@ def run(data_file, is_train=False, **args):
 
     if args.get('vocab_file', False):
         vocab_file = args['vocab_file']
-        vocab = util.load_vocab(vocab_file)
+        vocab = deepcrf.util.load_vocab(vocab_file)
 
     if args.get('vocab_char_file', False):
         vocab_char_file = args['vocab_char_file']
-        vocab_char = util.load_vocab(vocab_char_file)
+        vocab_char = deepcrf.util.load_vocab(vocab_char_file)
 
     vocab_tags_inv = dict((v, k) for k, v in vocab_tags.items())
     PAD_IDX = vocab[PADDING]
@@ -195,16 +198,16 @@ def run(data_file, is_train=False, **args):
         tmp_xp = np  # use CPU (numpy)
 
     def parse_to_word_ids(sentences, word_input_idx, vocab):
-        return util.parse_to_word_ids(sentences, xp=tmp_xp, vocab=vocab,
-                                      UNK_IDX=UNK_IDX, idx=word_input_idx)
+        return deepcrf.util.parse_to_word_ids(sentences, xp=tmp_xp, vocab=vocab,
+                                              UNK_IDX=UNK_IDX, idx=word_input_idx)
 
     def parse_to_char_ids(sentences):
-        return util.parse_to_char_ids(sentences, xp=tmp_xp, vocab_char=vocab_char,
-                                      UNK_IDX=CHAR_UNK_IDX, idx=word_input_idx)
+        return deepcrf.util.parse_to_char_ids(sentences, xp=tmp_xp, vocab_char=vocab_char,
+                                              UNK_IDX=CHAR_UNK_IDX, idx=word_input_idx)
 
     def parse_to_tag_ids(sentences):
-        return util.parse_to_tag_ids(sentences, xp=tmp_xp, vocab=vocab_tags,
-                                     UNK_IDX=-1, idx=-1)
+        return deepcrf.util.parse_to_tag_ids(sentences, xp=tmp_xp, vocab=vocab_tags,
+                                             UNK_IDX=-1, idx=-1)
 
     x_train = parse_to_word_ids(sentences_train, word_input_idx, vocab)
     x_char_train = parse_to_char_ids(sentences_train)
@@ -268,14 +271,14 @@ def run(data_file, is_train=False, **args):
     init_emb = None
 
     if is_train:
-        util.write_vocab(save_vocab, vocab)
-        util.write_vocab(save_vocab_char, vocab_char)
-        util.write_vocab(save_tags_vocab, vocab_tags)
-        util.write_vocab(save_train_config, args)
+        deepcrf.util.write_vocab(save_vocab, vocab)
+        deepcrf.util.write_vocab(save_vocab_char, vocab_char)
+        deepcrf.util.write_vocab(save_tags_vocab, vocab_tags)
+        deepcrf.util.write_vocab(save_train_config, args)
 
         for i, vocab_add in enumerate(vocab_adds):
             save_additional_vocab = save_name + '.vocab_additional_' + str(i)
-            util.write_vocab(save_additional_vocab, vocab_add)
+            deepcrf.util.write_vocab(save_additional_vocab, vocab_add)
 
     n_vocab_add = [len(_vadd) for _vadd in vocab_adds]
 
@@ -382,7 +385,7 @@ def run(data_file, is_train=False, **args):
             predict_dev, loss_dev, predict_dev_tags = eval_loop(
                 x_dev, x_char_dev, y_dev, x_dev_additionals)
             gold_predict_pairs = [y_dev_cpu, predict_dev_tags]
-            result, phrase_info = util.conll_eval(
+            result, phrase_info = deepcrf.util.conll_eval(
                 gold_predict_pairs, flag=False, tag_class=tag_names)
             all_result = result['All_Result']
             print('all_result: {}'.format(all_result))
@@ -407,7 +410,7 @@ def run(data_file, is_train=False, **args):
     t = 0.0
     prev_dev_accuracy = 0.0
     prev_dev_f = 0.0
-    for epoch in xrange(args['max_iter']):
+    for epoch in range(args['max_iter']):
 
         # train
         net.set_train(train=True)
@@ -444,7 +447,7 @@ def run(data_file, is_train=False, **args):
             predict_train.extend(predict)
 
         # Evaluation
-        train_accuracy = util.eval_accuracy(predict_train)
+        train_accuracy = deepcrf.util.eval_accuracy(predict_train)
 
         logging.info('epoch:' + str(epoch))
         logging.info(' [train]')
@@ -456,11 +459,11 @@ def run(data_file, is_train=False, **args):
             x_dev, x_char_dev, y_dev, x_dev_additionals)
 
         gold_predict_pairs = [y_dev_cpu, predict_dev_tags]
-        result, phrase_info = util.conll_eval(gold_predict_pairs, flag=False, tag_class=tag_names)
+        result, phrase_info = deepcrf.util.conll_eval(gold_predict_pairs, flag=False, tag_class=tag_names)
         all_result = result['All_Result']
 
         # Evaluation
-        dev_accuracy = util.eval_accuracy(predict_dev)
+        dev_accuracy = deepcrf.util.eval_accuracy(predict_dev)
         logging.info(' [dev]')
         logging.info('  loss     :' + str(loss_dev))
         logging.info('  accuracy :' + str(dev_accuracy))

--- a/deepcrf/main.py
+++ b/deepcrf/main.py
@@ -41,7 +41,7 @@ def my_cudnn(cudnn_flag):
 
 def run(data_file, is_train=False, **args):
     for k in args.keys():
-        args[k] = deepcrf.util.str_to_unicode_2(args[k])
+        args[k] = deepcrf.util.str_to_unicode_python2(args[k])
 
     is_test = not is_train
     batchsize = args['batchsize']

--- a/deepcrf/main.py
+++ b/deepcrf/main.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 to_cpu = chainer.cuda.to_cpu
 
 import os.path
+import six.moves
 
 version = chainer.__version__
 
@@ -410,7 +411,7 @@ def run(data_file, is_train=False, **args):
     t = 0.0
     prev_dev_accuracy = 0.0
     prev_dev_f = 0.0
-    for epoch in range(args['max_iter']):
+    for epoch in six.moves.range(args['max_iter']):
 
         # train
         net.set_train(train=True)

--- a/deepcrf/util.py
+++ b/deepcrf/util.py
@@ -50,8 +50,8 @@ def build_tag_vocab(dataset, tag_idx=-1):
 
 def write_vocab(filename, vocab):
     with open(filename, 'w') as f:
-        for w, idx in sorted(vocab.items(), key=lambda x: to_str(x[1])):
-            line = '\t'.join([unicode_to_str_2(w), to_str(idx)])
+        for e in sorted([[unicode_to_str_2(w), to_str(i)] for w, i in vocab.items()], key=lambda x: x[1]):
+            line = '\t'.join(e)
             f.write(line + '\n')
 
 

--- a/deepcrf/util.py
+++ b/deepcrf/util.py
@@ -5,6 +5,8 @@ import numpy as np
 
 from itertools import chain
 
+import six
+
 pattern_num = re.compile(r'[0-9]')
 CHAR_PADDING = u"_"
 UNKWORD = u"UNKNOWN"
@@ -48,8 +50,8 @@ def build_tag_vocab(dataset, tag_idx=-1):
 
 def write_vocab(filename, vocab):
     with open(filename, 'w') as f:
-        for w, idx in sorted(vocab.items(), key=lambda x: x[1]):
-            line = '\t'.join([w.encode('utf-8'), str(idx)])
+        for w, idx in sorted(vocab.items(), key=lambda x: to_str(x[1])):
+            line = '\t'.join([unicode_to_str_2(w), to_str(idx)])
             f.write(line + '\n')
 
 
@@ -57,7 +59,7 @@ def load_vocab(filename):
     vocab = {}
     with open(filename) as f:
         for l in f:
-            w, idx = l.decode('utf-8').strip().split(u'\t')
+            w, idx = str_to_unicode_2(l).strip().split(u'\t')
             vocab[w] = int(idx)
     return vocab
 
@@ -66,7 +68,7 @@ def read_raw_file(filename, delimiter=u' '):
     sentences = []
     with open(filename) as f:
         for l in f:
-            words = l.decode('utf-8').strip().split(delimiter)
+            words = str_to_unicode_2(l).strip().split(delimiter)
             words = [w.strip() for w in words if len(w.strip()) != 0]
             if len(words) and len(words[0]):
                 words = [(w, -1) for w in words]
@@ -80,7 +82,7 @@ def read_conll_file(filename, delimiter=u'\t', input_idx=0, output_idx=-1):
     n_features = -1
     with open(filename, 'r') as f:
         for line_idx, l in enumerate(f):
-            l_split = l.strip().decode('utf-8').split(delimiter)
+            l_split = str_to_unicode_2(l).strip().split(delimiter)
             l_split = [_.strip() for _ in l_split]
             if len(l_split) <= 1:
                 if len(sentence) > 0:
@@ -107,13 +109,13 @@ def load_glove_embedding(filename, vocab):
     word_vecs = []
     with open(filename) as f:
         for i, l in enumerate(f):
-            l = l.decode('utf-8').split(u' ')
+            l = str_to_unicode_2(l).split(u' ')
             word = l[0].lower()
 
             if word in vocab:
                 word_ids.append(vocab.get(word))
                 vec = l[1:]
-                vec = map(float, vec)
+                vec = list(map(float, vec))
                 word_vecs.append(vec)
     word_ids = np.array(word_ids, dtype=np.int32)
     word_vecs = np.array(word_vecs, dtype=np.float32)
@@ -128,12 +130,12 @@ def load_glove_embedding_include_vocab(filename):
 
     with open(filename) as f:
         for i, l in enumerate(f):
-            l = l.decode('utf-8').split(u' ')
+            l = str_to_unicode_2(l).split(u' ')
             word = l[0].lower()
             if word not in vocab:
                 vocab[word] = len(vocab)
                 vec = l[1:]
-                vec = map(float, vec)
+                vec = list(map(float, vec))
                 word_vecs.append(vec)
 
     # PADDING, UNKWORD
@@ -187,7 +189,7 @@ def conll_eval(gold_predict_pairs, flag=True, tag_class=None):
         cnt_phrases_dict[tag_name]['gold_cnt'] = 0
         cnt_phrases_dict[tag_name]['correct_cnt'] = 0
 
-    for i in xrange(len(gold_tags)):
+    for i in range(len(gold_tags)):
         gold = gold_tags[i]
         predict = predict_tags[i]
 
@@ -243,7 +245,7 @@ def IOB_to_range_format_one(tag_list, is_test_mode=False):
     ner = []
     ner_type = []
     # print(tag_list)
-    for i in xrange(len(tag_list)):
+    for i in range(len(tag_list)):
         prev_tag = tag_list[i - 1] if i != 0 else ''
         prev_tag_type = prev_tag[2:]
         # prev_tag_head = tag_list[i-1][0] if i != 0 else ''
@@ -328,3 +330,38 @@ def uniq_tagset(alltags_list, tag_names=[]):
             if tagname != u'' and tagname not in tag_names:
                 tag_names.append(tagname)
     return tag_names
+
+
+def to_str(s):
+    """
+    To str
+    :param s: something
+    :return: str
+    """
+    if six.PY2 and isinstance(s, unicode):
+        s = unicode_to_str_2(s)
+    elif not isinstance(s, str):
+        s = str(s)
+    return s
+
+
+def unicode_to_str_2(u):
+    """
+    Unicode to str when Python 2.x
+    :param u: unicode
+    :return: str
+    """
+    if six.PY2 and isinstance(u, unicode):
+        u = u.encode(sys.getfilesystemencoding())
+    return u
+
+
+def str_to_unicode_2(s):
+    """
+    Str to unicode when Python 2.x
+    :param s: str
+    :return: unicode
+    """
+    if six.PY2 and isinstance(s, str):
+        s = s.decode(sys.getfilesystemencoding())
+    return s

--- a/deepcrf/util.py
+++ b/deepcrf/util.py
@@ -50,7 +50,7 @@ def build_tag_vocab(dataset, tag_idx=-1):
 
 def write_vocab(filename, vocab):
     with open(filename, 'w') as f:
-        for e in sorted([[unicode_to_str_2(w), to_str(i)] for w, i in vocab.items()], key=lambda x: x[1]):
+        for e in sorted([[unicode_to_str_python2(w), to_str(i)] for w, i in vocab.items()], key=lambda x: x[1]):
             line = '\t'.join(e)
             f.write(line + '\n')
 
@@ -59,7 +59,7 @@ def load_vocab(filename):
     vocab = {}
     with open(filename) as f:
         for l in f:
-            w, idx = str_to_unicode_2(l).strip().split(u'\t')
+            w, idx = str_to_unicode_python2(l).strip().split(u'\t')
             vocab[w] = int(idx)
     return vocab
 
@@ -68,7 +68,7 @@ def read_raw_file(filename, delimiter=u' '):
     sentences = []
     with open(filename) as f:
         for l in f:
-            words = str_to_unicode_2(l).strip().split(delimiter)
+            words = str_to_unicode_python2(l).strip().split(delimiter)
             words = [w.strip() for w in words if len(w.strip()) != 0]
             if len(words) and len(words[0]):
                 words = [(w, -1) for w in words]
@@ -82,7 +82,7 @@ def read_conll_file(filename, delimiter=u'\t', input_idx=0, output_idx=-1):
     n_features = -1
     with open(filename, 'r') as f:
         for line_idx, l in enumerate(f):
-            l_split = str_to_unicode_2(l).strip().split(delimiter)
+            l_split = str_to_unicode_python2(l).strip().split(delimiter)
             l_split = [_.strip() for _ in l_split]
             if len(l_split) <= 1:
                 if len(sentence) > 0:
@@ -109,7 +109,7 @@ def load_glove_embedding(filename, vocab):
     word_vecs = []
     with open(filename) as f:
         for i, l in enumerate(f):
-            l = str_to_unicode_2(l).split(u' ')
+            l = str_to_unicode_python2(l).split(u' ')
             word = l[0].lower()
 
             if word in vocab:
@@ -130,7 +130,7 @@ def load_glove_embedding_include_vocab(filename):
 
     with open(filename) as f:
         for i, l in enumerate(f):
-            l = str_to_unicode_2(l).split(u' ')
+            l = str_to_unicode_python2(l).split(u' ')
             word = l[0].lower()
             if word not in vocab:
                 vocab[word] = len(vocab)
@@ -334,20 +334,20 @@ def uniq_tagset(alltags_list, tag_names=[]):
 
 def to_str(s):
     """
-    To str
+    Convert to str
     :param s: something
     :return: str
     """
     if six.PY2 and isinstance(s, unicode):
-        s = unicode_to_str_2(s)
+        s = unicode_to_str_python2(s)
     elif not isinstance(s, str):
         s = str(s)
     return s
 
 
-def unicode_to_str_2(u):
+def unicode_to_str_python2(u):
     """
-    Unicode to str when Python 2.x
+    In Python 2.x, convert unicode to str
     :param u: unicode
     :return: str
     """
@@ -356,9 +356,9 @@ def unicode_to_str_2(u):
     return u
 
 
-def str_to_unicode_2(s):
+def str_to_unicode_python2(s):
     """
-    Str to unicode when Python 2.x
+    In Python 2.x, convert str to unicode
     :param s: str
     :return: unicode
     """

--- a/deepcrf/util.py
+++ b/deepcrf/util.py
@@ -189,7 +189,7 @@ def conll_eval(gold_predict_pairs, flag=True, tag_class=None):
         cnt_phrases_dict[tag_name]['gold_cnt'] = 0
         cnt_phrases_dict[tag_name]['correct_cnt'] = 0
 
-    for i in range(len(gold_tags)):
+    for i in six.moves.range(len(gold_tags)):
         gold = gold_tags[i]
         predict = predict_tags[i]
 
@@ -245,7 +245,7 @@ def IOB_to_range_format_one(tag_list, is_test_mode=False):
     ner = []
     ner_type = []
     # print(tag_list)
-    for i in range(len(tag_list)):
+    for i in six.moves.range(len(tag_list)):
         prev_tag = tag_list[i - 1] if i != 0 else ''
         prev_tag_type = prev_tag[2:]
         # prev_tag_head = tag_list[i-1][0] if i != 0 else ''

--- a/deepcrf/util_talbes.py
+++ b/deepcrf/util_talbes.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
-import six
-
-if six.PY2:
-    from itertools import izip_longest
-else:
-    from itertools import zip_longest as izip_longest
+import six.moves
 
 
 class SimpleTable(object):
@@ -24,11 +19,11 @@ class SimpleTable(object):
 
     def _calc_maxes(self):
         array = [self.header] + self.rows
-        return [max(len(str(s)) for s in ss) for ss in izip_longest(*array, fillvalue='')]
+        return [max(len(str(s)) for s in ss) for ss in six.moves.zip_longest(*array, fillvalue='')]
 
     def _get_printable_row(self, row):
         maxes = self._calc_maxes()
-        return '| ' + ' | '.join([('{0: <%d}' % m).format(r) for r, m in izip_longest(row, maxes, fillvalue='')]) + ' |'
+        return '| ' + ' | '.join([('{0: <%d}' % m).format(r) for r, m in six.moves.zip_longest(row, maxes, fillvalue='')]) + ' |'
 
     def _get_printable_header(self):
         return self._get_printable_row(self.header)

--- a/deepcrf/util_talbes.py
+++ b/deepcrf/util_talbes.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-from itertools import izip_longest
+import six
+
+if six.PY2:
+    from itertools import izip_longest
+else:
+    from itertools import zip_longest as izip_longest
 
 
 class SimpleTable(object):

--- a/deepcrf/util_talbes.py
+++ b/deepcrf/util_talbes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import six.moves
+from six.moves import zip_longest
 
 
 class SimpleTable(object):
@@ -19,11 +19,11 @@ class SimpleTable(object):
 
     def _calc_maxes(self):
         array = [self.header] + self.rows
-        return [max(len(str(s)) for s in ss) for ss in six.moves.zip_longest(*array, fillvalue='')]
+        return [max(len(str(s)) for s in ss) for ss in zip_longest(*array, fillvalue='')]
 
     def _get_printable_row(self, row):
         maxes = self._calc_maxes()
-        return '| ' + ' | '.join([('{0: <%d}' % m).format(r) for r, m in six.moves.zip_longest(row, maxes, fillvalue='')]) + ' |'
+        return '| ' + ' | '.join([('{0: <%d}' % m).format(r) for r, m in zip_longest(row, maxes, fillvalue='')]) + ' |'
 
     def _get_printable_header(self):
         return self._get_printable_row(self.header)


### PR DESCRIPTION
#8 
I implemented to support Python2.x and Python 3.x.

However, the following error occurs  in Python 3.5 and Chainer v1.24.0 now:

```
[2017-10-04 20:16:35,868] [INFO] train:2087 (run@main.py:243)
[2017-10-04 20:16:35,869] [INFO] dev  :1426 (run@main.py:244)
[2017-10-04 20:16:35,869] [INFO] test :0 (run@main.py:245)
[2017-10-04 20:16:35,869] [INFO] vocab     :6138 (run@main.py:246)
[2017-10-04 20:16:35,869] [INFO] vocab_tags:32 (run@main.py:247)
[2017-10-04 20:16:35,869] [INFO] unk count (train):130 (run@main.py:248)
[2017-10-04 20:16:35,869] [INFO] unk rate  (train):0.0024291346674888354 (run@main.py:249)
[2017-10-04 20:16:35,869] [INFO] cnt all words (train):53517 (run@main.py:250)
[2017-10-04 20:16:35,869] [INFO] unk count (dev):83 (run@main.py:251)
[2017-10-04 20:16:35,869] [INFO] unk rate  (dev):0.0022682553563620465 (run@main.py:252)
[2017-10-04 20:16:35,869] [INFO] cnt all words (dev):36592 (run@main.py:253)
[2017-10-04 20:16:35,869] [INFO] ###################### (run@main.py:255)
[2017-10-04 20:16:35,869] [INFO] ## Model Config (run@main.py:256)
[2017-10-04 20:16:35,869] [INFO] model_name:bilstm-cnn-crf (run@main.py:257)
[2017-10-04 20:16:35,869] [INFO] batchsize:32 (run@main.py:258)
[2017-10-04 20:16:35,870] [INFO] optimizer:adam (run@main.py:259)
[2017-10-04 20:16:35,870] [INFO] ###################### (run@main.py:261)
[2017-10-04 20:16:35,870] [INFO] ## Model Save Config (run@main.py:262)
[2017-10-04 20:16:35,870] [INFO] save_dir :/home/suzuki/Documents/save_model_dir/ (run@main.py:263)
[2017-10-04 20:16:35,870] [INFO] save_vocab        :/home/suzuki/Documents/save_model_dir/bilstm-cnn-crf_adam.vocab (run@main.py:266)
[2017-10-04 20:16:35,870] [INFO] save_vocab_char   :/home/suzuki/Documents/save_model_dir/bilstm-cnn-crf_adam.vocab_char (run@main.py:267)
[2017-10-04 20:16:35,870] [INFO] save_tags_vocab   :/home/suzuki/Documents/save_model_dir/bilstm-cnn-crf_adam.vocab_tag (run@main.py:268)
[2017-10-04 20:16:35,870] [INFO] save_train_config :/home/suzuki/Documents/save_model_dir/bilstm-cnn-crf_adam.train_config (run@main.py:269)
[2017-10-04 20:16:36,166] [INFO] Lock 140506372007024 acquired on /home/suzuki/.cupy/kernel_cache/lock_file.lock (acquire@filelock.py:248)
[2017-10-04 20:16:36,166] [INFO] Lock 140506372007024 released on /home/suzuki/.cupy/kernel_cache/lock_file.lock (release@filelock.py:311)
[2017-10-04 20:16:36,169] [INFO] Lock 140506371941768 acquired on /home/suzuki/.cupy/kernel_cache/lock_file.lock (acquire@filelock.py:248)
[2017-10-04 20:16:36,169] [INFO] Lock 140506371941768 released on /home/suzuki/.cupy/kernel_cache/lock_file.lock (release@filelock.py:311)
[2017-10-04 20:16:36,171] [INFO] Lock 140506371941768 acquired on /home/suzuki/.cupy/kernel_cache/lock_file.lock (acquire@filelock.py:248)
[2017-10-04 20:16:36,171] [INFO] Lock 140506371941768 released on /home/suzuki/.cupy/kernel_cache/lock_file.lock (release@filelock.py:311)
[2017-10-04 20:16:36,174] [INFO] Lock 140506371941768 acquired on /home/suzuki/.cupy/kernel_cache/lock_file.lock (acquire@filelock.py:248)
[2017-10-04 20:16:36,174] [INFO] Lock 140506371941768 released on /home/suzuki/.cupy/kernel_cache/lock_file.lock (release@filelock.py:311)
[2017-10-04 20:16:36,176] [INFO] Lock 140506371941768 acquired on /home/suzuki/.cupy/kernel_cache/lock_file.lock (acquire@filelock.py:248)
[2017-10-04 20:16:36,176] [INFO] Lock 140506371941768 released on /home/suzuki/.cupy/kernel_cache/lock_file.lock (release@filelock.py:311)
Traceback (most recent call last):
  File "/home/suzuki/.virtualenvs/deep-crf3/bin/deep-crf", line 11, in <module>
    sys.exit(cli())
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/deepcrf/__init__.py", line 60, in train
    main.run(train_file, is_train=True, **args)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/deepcrf/main.py", line 436, in run
    output = net(x_data=x, x_char_data=x_char, x_additional=x_additional)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/deepcrf/bi_lstm.py", line 171, in __call__
    char_vecs = self.char_cnn(x_char_data_flat)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/deepcrf/cnn.py", line 138, in __call__
    char_vecs=char_vecs)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/deepcrf/cnn.py", line 120, in compute_vecs
    word_emb_conv = self.conv(word_embs_reshape)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/chainer/links/connection/convolution_2d.py", line 109, in __call__
    deterministic=self.deterministic)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/chainer/functions/connection/convolution_2d.py", line 417, in convolution_2d
    return func(x, W, b)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/chainer/function.py", line 199, in __call__
    outputs = self.forward(in_data)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/chainer/function.py", line 310, in forward
    return self.forward_gpu(inputs)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/chainer/functions/connection/convolution_2d.py", line 111, in forward_gpu
    y = cuda.cupy.empty((n, out_c, out_h, out_w), dtype=x.dtype)
  File "/home/suzuki/.virtualenvs/deep-crf3/lib/python3.5/site-packages/cupy/creation/basic.py", line 19, in empty
    return cupy.ndarray(shape, dtype=dtype, order=order)
  File "cupy/core/core.pyx", line 70, in cupy.core.core.ndarray.__init__ (cupy/core/core.cpp:6208)
  File "stringsource", line 52, in vector.from_py.__pyx_convert_vector_from_py_Py_ssize_t (cupy/core/core.cpp:83049)
TypeError: 'float' object cannot be interpreted as an integer
```
I think valiable `word_embs_reshape` in deepcrf/cnn.py line 120 maybe a cause of this error, but I haven't been able to find a solution yet.