### PR TITLE
Add h5py as requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     include_package_data=False,
     install_requires=[
         'Click',
+        'h5py'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
I added `h5py` as requires (`h5py` is used for model serialization).