### PR TITLE
Replace six.moves.range with six.moves.xrange

### DIFF
--- a/deepcrf/bi_lstm.py
+++ b/deepcrf/bi_lstm.py
@@ -72,7 +72,7 @@ class BiLSTM_CNN_CRF(chainer.Chain):
             self.add_link('char_cnn', char_cnn)
 
         if self.n_add_feature:
-            for i in six.moves.range(self.n_add_feature):
+            for i in six.moves.xrange(self.n_add_feature):
                 n_add_vocab = n_vocab_add[i]
                 add_embed = L.EmbedID(n_add_vocab, n_add_feature_dim, ignore_label=-1)
                 self.add_link('add_embed_' + str(i), add_embed)
@@ -181,7 +181,7 @@ class BiLSTM_CNN_CRF(chainer.Chain):
                 x = F.concat([x, x_char], axis=1)
 
             if x_additional:
-                for add_i in six.moves.range(self.n_add_feature):
+                for add_i in six.moves.xrange(self.n_add_feature):
                     x_add = x_additional[add_i][i]
                     x_add = my_variable(x_add, volatile=not self.train)
                     add_emb_layer = self.get_layer('add_embed_' + str(add_i))

--- a/deepcrf/cnn.py
+++ b/deepcrf/cnn.py
@@ -61,7 +61,7 @@ class BaseCNNEncoder(chainer.Chain):
         """
 
         padding_size = self.window_size // 2
-        padding = [self.PAD_IDX for i in six.moves.range(padding_size)]
+        padding = [self.PAD_IDX for i in six.moves.xrange(padding_size)]
         padding = self.xp.array(padding, dtype=self.xp.int32)
         data_num = len(data)
         ids = []

--- a/deepcrf/main.py
+++ b/deepcrf/main.py
@@ -406,7 +406,7 @@ def run(data_file, is_train=False, **args):
     t = 0.0
     prev_dev_accuracy = 0.0
     prev_dev_f = 0.0
-    for epoch in six.moves.range(args['max_iter']):
+    for epoch in six.moves.xrange(args['max_iter']):
 
         # train
         net.set_train(train=True)

--- a/deepcrf/util.py
+++ b/deepcrf/util.py
@@ -189,7 +189,7 @@ def conll_eval(gold_predict_pairs, flag=True, tag_class=None):
         cnt_phrases_dict[tag_name]['gold_cnt'] = 0
         cnt_phrases_dict[tag_name]['correct_cnt'] = 0
 
-    for i in six.moves.range(len(gold_tags)):
+    for i in six.moves.xrange(len(gold_tags)):
         gold = gold_tags[i]
         predict = predict_tags[i]
 
@@ -249,7 +249,7 @@ def IOB_to_range_format_one(tag_list, is_test_mode=False):
     ner = []
     ner_type = []
     # print(tag_list)
-    for i in six.moves.range(len(tag_list)):
+    for i in six.moves.xrange(len(tag_list)):
         prev_tag = tag_list[i - 1] if i != 0 else ''
         prev_tag_type = prev_tag[2:]
         # prev_tag_head = tag_list[i-1][0] if i != 0 else ''


### PR DESCRIPTION
I replaced `six.moves.xrange` with `six.moves.xrange` because `six.moves.xrange` is the same as `six.moves.range` and I think `six.moves.xrange` is a method name that is easier to understand than `six.moves.range`.