### PR TITLE
Describe supported version of Python in more detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A implementation of Conditional Random Fields (CRFs) with Deep Learning Method.
 
 DeepCRF is a sequence labeling library that uses neural networks and CRFs in Python using Chainer, a flexible deep learning framework.
 
-## Supported version of Python
-* Python 2.x
-* Python 3.x
+## Which version of Python is supported?
+* Python 2.7
+* Python 3.4 or later
 
 ## How to install?
 ```


### PR DESCRIPTION
#8 
I described supported version of Python in more detail (`numpy 1.13.3` required for `h5py` supports Python 2.7 or Python 3.4 or later).