### PR TITLE
Fix version of Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DeepCRF is a sequence labeling library that uses neural networks and CRFs in Pyt
 
 ## Which version of Python is supported?
 * Python 2.7
-* Python 3.4 or later
+* Python 3.4
 
 ## Which version of Chainer is supported?
 * Chainer v1.24.0


### PR DESCRIPTION
Releated to #8.
Chainer v.2.1.0 and v1.24.0 source codes say it won't work with Python 3.5.0.
So I fix supported version of Python.